### PR TITLE
MySQLをPostgresqlに置き換え

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 appraise 'ar42' do
   gem 'activerecord', '~> 4.2.10'
-  gem 'mysql2', '< 0.5'
+  gem 'pg'
 end
 
 appraise 'ar50' do

--- a/activerecord_mysql_xverify.gemspec
+++ b/activerecord_mysql_xverify.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord'
-  spec.add_dependency 'mysql2'
+  spec.add_dependency 'pg'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/gemfiles/ar42.gemfile
+++ b/gemfiles/ar42.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.10"
-gem "mysql2", "< 0.5"
+gem "pg"
 
 gemspec path: "../"

--- a/lib/active_record_mysql_xverify.rb
+++ b/lib/active_record_mysql_xverify.rb
@@ -10,8 +10,7 @@ require 'active_record_mysql_xverify/verifier'
 require 'active_record_mysql_xverify/verifiers/aurora_master'
 
 ActiveSupport.on_load :active_record do
-  require 'active_record/connection_adapters/abstract_mysql_adapter'
-  require 'active_record/connection_adapters/mysql2_adapter'
-  ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend ActiveRecordMysqlXverify::ErrorHandler
-  ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend ActiveRecordMysqlXverify::Verifier
+  require 'active_record/connection_adapters/postgresql_adapter'
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend ActiveRecordMysqlXverify::Verifier
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend ActiveRecordMysqlXverify::ErrorHandler
 end

--- a/lib/active_record_mysql_xverify/error_handler.rb
+++ b/lib/active_record_mysql_xverify/error_handler.rb
@@ -1,6 +1,6 @@
 module ActiveRecordMysqlXverify
   module ErrorHandler
-    def execute(*)
+    def execute_and_clear(*)
       super
     rescue StandardError
       _flag_extend_verify!

--- a/lib/active_record_mysql_xverify/utils.rb
+++ b/lib/active_record_mysql_xverify/utils.rb
@@ -7,8 +7,7 @@ module ActiveRecordMysqlXverify
                     rescue StandardError
                       nil
                     end
-
-        "host=#{conn.query_options[:host]}, database=#{conn.query_options[:database]}, " \
+        "host=#{conn.conninfo_hash[:host]}, dbname=#{conn.conninfo_hash[:dbname]}, " \
           "username=#{conn.query_options[:username]}, thread_id=#{thread_id}"
       end
     end

--- a/lib/active_record_mysql_xverify/verifiers/aurora_master.rb
+++ b/lib/active_record_mysql_xverify/verifiers/aurora_master.rb
@@ -1,7 +1,7 @@
 module ActiveRecordMysqlXverify
   module Verifiers
     AURORA_MASTER = lambda do |conn|
-      conn.ping && conn.query('show variables like "innodb_read_only"').first.fetch(1) == 'OFF'
+      conn.ping && conn.query('show transaction_read_only').first.fetch(1) == 'OFF'
     end
   end
 end


### PR DESCRIPTION
# gemの仕組み
[作者のブログ](https://so-wh.at/entry/2018/11/19/184743)にもある通り、コネクションプールからのチェックアウト時の挙動を上書き

## ActiveRecord既存の挙動

1. [ActiveRecord::ConnectionAdapters::AbstractAdapter.checkout](https://github.com/rails/rails/blob/v5.2.1/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L434)
2. [checkout_and_verify](https://github.com/rails/rails/blob/v5.2.1/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L856)
3. [ActiveRecord::ConnectionAdapters::AbstractAdapter.verify!](https://github.com/rails/rails/blob/v5.2.1/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L434)
4. [ActiveRecord::ConnectionAdapters::PostgresqlAdapter.active?](https://github.com/rails/rails/blob/94b5cd3a20edadd6f6b8cf0bdf1a4d4919df86cb/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L262)

4の`active?`メソッドをエラー時にのみ

# 変更内容
